### PR TITLE
add additional links next to the first column

### DIFF
--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -1,3 +1,8 @@
 .p-inline-list {
   padding-top: 4rem;
 }
+
+.p-icon--chevron-up {
+  background-size: 0.8rem 0.8rem;
+  margin-left: 0.25rem;
+}

--- a/src/components/Footer/Footer.stories.mdx
+++ b/src/components/Footer/Footer.stories.mdx
@@ -44,6 +44,28 @@ This is a [React](https://reactjs.org/) component for a store footer.
           altText: "Link 3",
         },
       ],
+      additionalLinks: [
+        {
+          name: "Terms of service",
+          href: "https://ubuntu.com/legal/terms-and-policies",
+        },
+        {
+          name: "Data privacy",
+          href: "https://ubuntu.com/legal/data-privacy?_ga=2.40064295.449174614.1676317399-1455078266.1676317399",
+        },
+        {
+          name: "Manage your tracker settings",
+          href: "https://charmhub.io/",
+        },
+        {
+          name: "Service status",
+          href: "https://discourse.charmhub.io/t/status-values/1168",
+        },
+        {
+          name: "Other functions",
+          href: "https://juju.is/docs/sdk/set-up-a-charm-project",
+        },
+      ],
     }}
   >
     {Template.bind({})}

--- a/src/components/Footer/Footer.test.tsx
+++ b/src/components/Footer/Footer.test.tsx
@@ -19,6 +19,12 @@ describe("Footer", () => {
         altText: "Link 2",
       },
     ],
+    additionalLinks: [
+      {
+        name: "Terms of service",
+        href: "https://example.com/link3",
+      },
+    ],
   };
 
   it("renders", () => {

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Row, Col, Strip } from "@canonical/react-components";
+import { Row, Col, Strip, Link } from "@canonical/react-components";
 
 import "./Footer.scss";
 
@@ -19,6 +19,10 @@ function Footer({ socialLinks }: Props) {
     <Strip type="light">
       <Row className="u-equal-height">
         <Col size={4}>
+          <a className="p-link--soft" href="#">
+            Back to top
+            <i className="p-icon--chevron-up"></i>
+          </a>
           <p>© {new Date().getFullYear()} Canonical Ltd.</p>
           <ul className="p-inline-list">
             {socialLinks &&

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Row, Col, Strip, Link } from "@canonical/react-components";
+import { Row, Col, Strip } from "@canonical/react-components";
 
 import "./Footer.scss";
 
@@ -10,11 +10,17 @@ type SocialLink = {
   altText: string;
 };
 
-export type Props = {
-  socialLinks: SocialLink[];
+type AdditionalLink = {
+  name: string;
+  href: string;
 };
 
-function Footer({ socialLinks }: Props) {
+export type Props = {
+  socialLinks: SocialLink[];
+  additionalLinks: AdditionalLink[];
+};
+
+function Footer({ socialLinks, additionalLinks }: Props) {
   return (
     <Strip type="light">
       <Row className="u-equal-height">
@@ -42,43 +48,12 @@ function Footer({ socialLinks }: Props) {
         </Col>
         <Col size={6}>
           <ul className="p-list">
-            <li className="p-list__item">
-              <Link
-                className="p-link"
-                href="https://ubuntu.com/legal/terms-and-policies"
-              >
-                Terms of service
-              </Link>
-            </li>
-            <li className="p-list__item">
-              <Link
-                className="p-link"
-                href="https://ubuntu.com/legal/data-privacy?_ga=2.40064295.449174614.1676317399-1455078266.1676317399"
-              >
-                Data privacy
-              </Link>
-            </li>
-            <li className="p-list__item">
-              <Link className="p-link" href="https://charmhub.io/">
-                Manage your tracker settings
-              </Link>
-            </li>
-            <li className="p-list__item">
-              <Link
-                className="p-link"
-                href="https://discourse.charmhub.io/t/status-values/1168"
-              >
-                Service status
-              </Link>
-            </li>
-            <li className="p-list__item">
-              <Link
-                className="p-link"
-                href="https://juju.is/docs/sdk/set-up-a-charm-project"
-              >
-                Other functions
-              </Link>
-            </li>
+            {additionalLinks &&
+              additionalLinks.map((additionalLink) => (
+                <li className="p-list__item" key={additionalLink?.name}>
+                  <a href={additionalLink?.href}>{additionalLink?.name}</a>
+                </li>
+              ))}
           </ul>
         </Col>
       </Row>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -18,7 +18,7 @@ function Footer({ socialLinks }: Props) {
   return (
     <Strip type="light">
       <Row className="u-equal-height">
-        <Col size={4}>
+        <Col size={3}>
           <a className="p-link--soft" href="#">
             Back to top
             <i className="p-icon--chevron-up"></i>
@@ -38,6 +38,47 @@ function Footer({ socialLinks }: Props) {
                   </a>
                 </li>
               ))}
+          </ul>
+        </Col>
+        <Col size={6}>
+          <ul className="p-list">
+            <li className="p-list__item">
+              <Link
+                className="p-link"
+                href="https://ubuntu.com/legal/terms-and-policies"
+              >
+                Terms of service
+              </Link>
+            </li>
+            <li className="p-list__item">
+              <Link
+                className="p-link"
+                href="https://ubuntu.com/legal/data-privacy?_ga=2.40064295.449174614.1676317399-1455078266.1676317399"
+              >
+                Data privacy
+              </Link>
+            </li>
+            <li className="p-list__item">
+              <Link className="p-link" href="https://charmhub.io/">
+                Manage your tracker settings
+              </Link>
+            </li>
+            <li className="p-list__item">
+              <Link
+                className="p-link"
+                href="https://discourse.charmhub.io/t/status-values/1168"
+              >
+                Service status
+              </Link>
+            </li>
+            <li className="p-list__item">
+              <Link
+                className="p-link"
+                href="https://juju.is/docs/sdk/set-up-a-charm-project"
+              >
+                Other functions
+              </Link>
+            </li>
           </ul>
         </Col>
       </Row>


### PR DESCRIPTION
## Done
Allowed additional links to be added next to the social links list

## QA Steps
- Go to https://store-components-19.demos.haus/?path=/story/footer--default-story
- Check if there are additional links in the second column in the footer 

## Fixes
Fixes: https://warthogs.atlassian.net/browse/WD-1615
