### PR TITLE
Hide overflow on package cards

### DIFF
--- a/src/components/PackageCard/PackageCard.scss
+++ b/src/components/PackageCard/PackageCard.scss
@@ -4,6 +4,7 @@
 
 .p-card__content {
   height: 100%;
+  overflow: hidden;
 }
 
 .sc-package-card {


### PR DESCRIPTION
## Done

Hide overflow on package cards

## QA
Can only QA if row of cards in the grid. Just trust me. It works.