### PR TITLE
Fix bundle cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/store-components",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "author": "Canonical",

--- a/src/components/BundleCard/BundleCard.tsx
+++ b/src/components/BundleCard/BundleCard.tsx
@@ -6,7 +6,7 @@ function BundleCard({ data }) {
   return (
     <PackageCard
       data={data}
-      showIcon
+      showIcon={false}
       showVerification
       showFeaturedPackages
       isBundle

--- a/src/components/PackageCard/InnerCard.tsx
+++ b/src/components/PackageCard/InnerCard.tsx
@@ -66,6 +66,12 @@ function InnerCard({
         style={{ width: "100%", height: height }}
       >
         <div className="sc-package-card__body">
+          {isBundle && (
+            <div className="sc-package-card__header">
+              <h3 className="p-muted-heading u-no-margin--bottom">Bundle</h3>
+            </div>
+          )}
+
           {data.package.display_name && (
             <h2 className="sc-package-card__heading p-heading--5 u-no-margin--bottom">
               {data.package.name ? (
@@ -107,12 +113,6 @@ function InnerCard({
                 </>
               )}
             </p>
-          )}
-
-          {isBundle && (
-            <div className="sc-package-card__header">
-              <h3 className="p-muted-heading u-no-margin--bottom">Bundle</h3>
-            </div>
           )}
 
           <p className="u-line-clamp">{data.package.description}</p>


### PR DESCRIPTION
## Done
Moved position of bundle card title

## QA
- Run locally: `yarn docs`
- Go to http://localhost:9009/?path=/docs/bundlecard--docs
- Check the "Bundle" heading is above title

## Issue
Fixes https://warthogs.atlassian.net/browse/WD-7672