### PR TITLE
Add placeholder image

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/store-components",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "author": "Canonical",

--- a/src/components/DefaultCard/DefaultCard.stories.mdx
+++ b/src/components/DefaultCard/DefaultCard.stories.mdx
@@ -336,3 +336,67 @@ This is a [React](https://reactjs.org/) component for a default package card.
     {Template.bind({})}
   </Story>
 </Canvas>
+
+## Missing icon URL
+
+<Canvas>
+  <Story
+    name="Missing icon URL"
+    args={{
+      data: {
+        package: {
+          charms: [
+            {
+              display_name: "Traefik Ingress",
+              name: "traefik-k8s",
+            },
+            {
+              display_name: "MicroK8s",
+              name: "microk8s",
+            },
+            {
+              display_name: "Kafka",
+              name: "kafka",
+            },
+            {
+              display_name: "PostgreSQL",
+              name: "postgresql",
+            },
+            {
+              display_name: "Prometheus",
+              name: "prometheus-k8s",
+            },
+            {
+              display_name: "Landscape Server",
+              name: "landscape-server",
+            },
+            {
+              display_name: "Grafana",
+              name: "grafana-k8s",
+            },
+            {
+              display_name: "LXD",
+              name: "lxd",
+            },
+          ],
+          description:
+            "Privacy-oriented voice, video, chat, and conference platform and SIP phone",
+          display_name: "Jami",
+          icon_url: "",
+          name: "jami",
+          platforms: ["vm", "kubernetes"],
+        },
+        categories: [
+          { name: "books-and-reference", featured: true },
+          { name: "development", featured: false },
+        ],
+        ratings: {
+          value: 4,
+          count: 50,
+        },
+      },
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/src/components/DefaultCard/DefaultCard.tsx
+++ b/src/components/DefaultCard/DefaultCard.tsx
@@ -2,17 +2,28 @@ import React from "react";
 
 import PackageCard from "components/PackageCard";
 
-function DefaultCard({ data }) {
-  const isFeatured = data?.categories.find((cat) => {
-    return cat.featured;
-  });
+import type { Package } from "types/package";
+
+type Props = {
+  data: Package;
+};
+
+function DefaultCard({ data }: Props) {
+  let isFeatured = false;
+
+  if (data.categories && data.categories.length > 0) {
+    const featuredPackage = data.categories.find((cat) => cat.featured);
+    if (featuredPackage) {
+      isFeatured = true;
+    }
+  }
 
   return (
     <PackageCard
       data={data}
       showIcon
       showVerification
-      isHighlighted={isFeatured || false}
+      isHighlighted={isFeatured}
     />
   );
 }

--- a/src/components/PackageCard/PackageCard.tsx
+++ b/src/components/PackageCard/PackageCard.tsx
@@ -61,7 +61,12 @@ function PackageCard({
   return (
     <Card style={outerCardStyle} onClick={handleClick}>
       {showIcon ? (
-        <IconCard iconUrl={data.package.icon_url}>
+        <IconCard
+          iconUrl={
+            data.package.icon_url ||
+            "https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg"
+          }
+        >
           <InnerCard data={data} {...innerCardProps} height="100%" />
         </IconCard>
       ) : (

--- a/src/types/package.ts
+++ b/src/types/package.ts
@@ -19,6 +19,7 @@ export type Package = {
   categories?: Array<{
     display_name: string;
     name: string;
+    featured?: boolean;
   }>;
   ratings?: {
     value: number | null;


### PR DESCRIPTION
## Done
- Added a placeholder image for missing icons
- Also fixed bug with featured categories

## QA
- Go to https://store-components-96.demos.haus/?path=/story/defaultcard--missing-icon-url
- Check that there is a placeholder icon