### PR TITLE
Remove bottom margin on default cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/store-components",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "author": "Canonical",

--- a/src/components/PackageCard/InnerCard.tsx
+++ b/src/components/PackageCard/InnerCard.tsx
@@ -115,7 +115,15 @@ function InnerCard({
             </p>
           )}
 
-          <p className="u-line-clamp">{data.package.description}</p>
+          <p
+            className={`u-line-clamp ${
+              !showRatings && !showFeaturedPackages && !showPlatforms
+                ? "u-no-margin--bottom"
+                : ""
+            }`}
+          >
+            {data.package.description}
+          </p>
 
           {showRatings && (
             <div className="star-rating" data-testid="ratings">


### PR DESCRIPTION
## Done
Removed bottom margin from description in cards unless there is a footer

## QA
- Go to https://store-components-98.demos.haus/?path=/story/defaultcard--default-story
- Check that there is no margin on the description