### PR TITLE
Update featured snaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/store-components",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "author": "Canonical",

--- a/src/components/DefaultCard/DefaultCard.stories.mdx
+++ b/src/components/DefaultCard/DefaultCard.stories.mdx
@@ -325,6 +325,7 @@ This is a [React](https://reactjs.org/) component for a default package card.
         categories: [
           { name: "books-and-reference", featured: true },
           { name: "development", featured: false },
+          { name: "featured", featured: true },
         ],
         ratings: {
           value: 4,

--- a/src/components/DefaultCard/DefaultCard.tsx
+++ b/src/components/DefaultCard/DefaultCard.tsx
@@ -12,7 +12,9 @@ function DefaultCard({ data }: Props) {
   let isFeatured = false;
 
   if (data.categories && data.categories.length > 0) {
-    const featuredPackage = data.categories.find((cat) => cat.featured);
+    const featuredPackage = data.categories.find(
+      (cat) => cat.name === "featured"
+    );
     if (featuredPackage) {
       isFeatured = true;
     }


### PR DESCRIPTION
## Done
Changed the way featured cards are selected

## QA
- Go to https://store-components-104.demos.haus/?path=/story/defaultcard--featured
- or `yarn docs` and go to  http://localhost:9009/?path=/story/defaultcard--featured
- Check that the card has a coloured border on top