### PR TITLE
docs: Add link to React Components library

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a collection of components designed to be used in store UIs when using React. This is currently a work in progress and therefore not recommended to use in projects at this time.
 
+These components are an extension of the [Vanilla React Components](https://github.com/canonical/react-components) library.
+
 ## How to use the components
 
 See the [component docs](https://canonical.github.io/store-components/) for usage instructions.


### PR DESCRIPTION
## Done
Added a link to the React Components library to the README

## QA
Check that there is a link to the React Components library in the first section of the README

## Fixes
Fixes https://warthogs.atlassian.net/browse/WD-11245