### PR TITLE
Fix Sass warnings

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -13,7 +13,19 @@ module.exports = {
   webpackFinal: async (config, { configType }) => {
     config.module.rules.push({
       test: /\.scss$/,
-      use: ["style-loader", "css-loader", "sass-loader"],
+      use: [
+        "style-loader",
+        "css-loader",
+        {
+          loader: "sass-loader",
+          options: {
+            sassOptions: {
+              quietDeps: true,
+              silenceDeprecations: ["import"],
+            },
+          },
+        },
+      ],
       include: path.resolve(__dirname, "../"),
     });
     return config;

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,6 @@
 import { DocsContainer } from "@storybook/addon-docs";
 import { themes } from "@storybook/theming";
-import "vanilla-framework/scss/build.scss";
+import "./vanilla.scss";
 
 // or global addParameters
 export const parameters = {

--- a/.storybook/vanilla.scss
+++ b/.storybook/vanilla.scss
@@ -1,0 +1,2 @@
+@import "vanilla-framework";
+@include vanilla;

--- a/src/components/LoadingCard/LoadingCard.scss
+++ b/src/components/LoadingCard/LoadingCard.scss
@@ -1,14 +1,4 @@
 .p-card--placeholder {
-  @keyframes shine {
-    0% {
-      background-position: right;
-    }
-
-    100% {
-      background-position: left;
-    }
-  }
-
   animation: shine 3s infinite ease-in-out;
   background-image: linear-gradient(
     to bottom right,
@@ -18,4 +8,14 @@
   );
   background-size: 300% 300%;
   clip-path: url("#animation-mask");
+
+  @keyframes shine {
+    0% {
+      background-position: right;
+    }
+
+    100% {
+      background-position: left;
+    }
+  }
 }


### PR DESCRIPTION
## Done

- Updates sass-loader config to ignore warnings from dependencies (and warnings about imports)
- Extracts Vanilla import to SCSS file, so it can be correctly detected as a dependency import
- Updates necessary SCSS files to fix warnings

## QA



- Check CI build, there should be no SCSS warnings
- Or locally run `yarn build` and `yarn build-docs` (there should be no warnings from Sass)
- Check if demo works as expected https://store-components-148.demos.haus/


## Fixes

Fixes: WD-18313
