### PR TITLE
Fix long package name overlap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/store-components",
-  "version": "0.54.0",
+  "version": "0.54.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "author": "Canonical",

--- a/src/components/RockCard/RockCard.scss
+++ b/src/components/RockCard/RockCard.scss
@@ -8,17 +8,21 @@
     align-content: space-between;
 }
 
-.sc-rock-card__body {
-    position: relative;
-}
-
 .sc-rock-support-chip {
-    position: absolute;
-    right: 0;
+    opacity: 0.7;
+    height: 22px;
+    min-width: 39px;
+    padding: 0;
 }
 
 .sc-rock-card__footer {
     margin-top: auto;
+}
+
+.sc-rock-card__details-wrapper {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
 }
 
 .sc-rock-card__footer-content {

--- a/src/components/RockCard/RockCard.scss
+++ b/src/components/RockCard/RockCard.scss
@@ -28,4 +28,9 @@
 .sc-rock-card__footer-content {
     display: flex;
     justify-content: space-between;
+
+    @media screen and (max-width: $breakpoint-x-small) {
+        flex-direction: column;  
+    }
+
 }

--- a/src/components/RockCard/RockCard.tsx
+++ b/src/components/RockCard/RockCard.tsx
@@ -35,56 +35,57 @@ function RockCard({ data, showVerification }: PackageCardProps) {
             data-testid="package-icon"
             alt="Package icon"
           />
+          <div className="sc-rock-card__details-wrapper">
+            <div className="p-media-object__details">
+              {data.package.display_name && (
+                <h2 className="p-heading--5 u-no-margin--bottom u-no-padding--top">
+                  {data.package.display_name}
+                </h2>
+              )}
 
-          <div className="p-meida-object__details">
-            {data.package.display_name && (
-              <h2 className="p-heading--5 u-no-margin--bottom u-no-padding--top">
-                {data.package.display_name}
-              </h2>
-            )}
+              {data.publisher && (
+                <p className="u-text--muted u-no-padding--top">
+                  <em>{data.publisher.display_name} </em>
+                  {showVerification && (
+                    <>
+                      {data.publisher.validation === "verified" && (
+                        <img
+                          src="https://assets.ubuntu.com/v1/ba8a4b7b-Verified.svg"
+                          width={14}
+                          height={14}
+                          alt="Verified account"
+                          title="Verified account"
+                          className="sc-package-publisher-icon"
+                        />
+                      )}
 
-            {data.publisher && (
-              <p className="u-text--muted u-no-padding--top">
-                <em>{data.publisher.display_name} </em>
-                {showVerification && (
-                  <>
-                    {data.publisher.validation === "verified" && (
-                      <img
-                        src="https://assets.ubuntu.com/v1/ba8a4b7b-Verified.svg"
-                        width={14}
-                        height={14}
-                        alt="Verified account"
-                        title="Verified account"
-                        className="sc-package-publisher-icon"
-                      />
-                    )}
-
-                    {(data.publisher.validation === "star" ||
-                      data.publisher.validation === "starred") && (
-                      <img
-                        src="https://assets.ubuntu.com/v1/d810dee9-Orange+Star.svg"
-                        width={14}
-                        height={14}
-                        alt="Star developer"
-                        title="Star developer"
-                        className="sc-package-publisher-icon"
-                      />
-                    )}
-                  </>
-                )}
-              </p>
-            )}
-            <p className={"u-line-clamp"}>{data.package.summary}</p>
+                      {(data.publisher.validation === "star" ||
+                        data.publisher.validation === "starred") && (
+                        <img
+                          src="https://assets.ubuntu.com/v1/d810dee9-Orange+Star.svg"
+                          width={14}
+                          height={14}
+                          alt="Star developer"
+                          title="Star developer"
+                          className="sc-package-publisher-icon"
+                        />
+                      )}
+                    </>
+                  )}
+                </p>
+              )}
+              <p className={"u-line-clamp"}>{data.package.summary}</p>
+            </div>
+            <button className="p-chip--caution sc-rock-support-chip">
+              <span className="p-chip__value">{data.package.support}</span>
+            </button>
           </div>
-          <button className="p-chip--caution sc-rock-support-chip">
-            <span className="p-chip__value">LTS</span>
-          </button>
         </div>
         {(data.package.last_updated || data.package.cves) && (
           <div className="sc-rock-card__footer">
             <hr />
             <div className="sc-rock-card__footer-content">
-              {data.package.support && (
+              {data.package.cves && (
                 <p
                   className="u-text--small u-no-padding--top u-no-margin--bottom"
                   data-testid="package-channel"
@@ -98,8 +99,9 @@ function RockCard({ data, showVerification }: PackageCardProps) {
                   className="u-text--muted u-no-margin--bottom"
                   data-testid="package-channel"
                 >
+                  <i className="p-icon--change-version"></i>&nbsp;
                   <em>
-                    <i className="p-icon--change-version"></i>&nbsp;Updated
+                    Updated&nbsp;
                     {data.package.last_updated}
                   </em>
                 </p>


### PR DESCRIPTION
## Done

- Fix long package name overlap
- Remove hard-coded `LTS`

## QA
- Go to [demo](https://store-components-162.demos.haus/?path=/docs/rockcard--docs)
- Check on small screen, check that the package name does not overlap the `LTS` chip, it should wrap to next line.
